### PR TITLE
Only post verbosity message confirmation if verbosity > 0

### DIFF
--- a/midifile.c
+++ b/midifile.c
@@ -1382,7 +1382,7 @@ static unsigned char *midifile_read_var_len (unsigned char *cP, uint32_t *delta)
 static void midifile_verbosity(t_midifile *x, t_floatarg verbosity)
 {
     x->verbosity = (int)verbosity;
-    post ("midifile verbosity is %d", x->verbosity);
+    if (x->verbosity) post("midifile verbosity is %d", x->verbosity);
 }
 
 /** midifile_set_track implements the track message.


### PR DESCRIPTION
This is a little annoyance to me: when sending a `[verbose 0<` message, I don't want to see a confirmation "midifile verbosity 0" post since IMO verbosity 0 means silent.